### PR TITLE
Mvdb/jkr 9457/django 1.8 compat

### DIFF
--- a/mongodbforms/documents.py
+++ b/mongodbforms/documents.py
@@ -8,7 +8,10 @@ from django.forms.forms import (BaseForm, get_declared_fields,
 from django.forms.widgets import media_property
 from django.core.exceptions import FieldError
 from django.core.validators import EMPTY_VALUES
-from django.forms.util import ErrorList
+try:
+    from django.forms.utils import ErrorList
+except ImportError:
+    from django.forms.util import ErrorList
 from django.forms.formsets import BaseFormSet, formset_factory
 from django.utils.translation import ugettext_lazy as _, ugettext
 from django.utils.text import capfirst, get_valid_filename

--- a/mongodbforms/documents.py
+++ b/mongodbforms/documents.py
@@ -9,7 +9,7 @@ from django.forms.widgets import media_property
 from django.core.exceptions import FieldError
 from django.core.validators import EMPTY_VALUES
 try:
-    from django.forms.utils import ErrorList
+    from django.forms.utils import ErrorList  # Django 1.8
 except ImportError:
     from django.forms.util import ErrorList
 from django.forms.formsets import BaseFormSet, formset_factory

--- a/mongodbforms/fields.py
+++ b/mongodbforms/fields.py
@@ -25,7 +25,7 @@ except ImportError:
         
 from django.utils.translation import ugettext_lazy as _
 try:
-    from django.forms.utils import ErrorList
+    from django.forms.utils import ErrorList  # Django 1.8
 except ImportError:
     from django.forms.util import ErrorList
 from django.core.exceptions import ValidationError

--- a/mongodbforms/fields.py
+++ b/mongodbforms/fields.py
@@ -24,7 +24,10 @@ except ImportError:
         from django.forms.util import smart_unicode
         
 from django.utils.translation import ugettext_lazy as _
-from django.forms.util import ErrorList
+try:
+    from django.forms.utils import ErrorList
+except ImportError:
+    from django.forms.util import ErrorList
 from django.core.exceptions import ValidationError
 
 try:  # objectid was moved into bson in pymongo 1.9

--- a/mongodbforms/util.py
+++ b/mongodbforms/util.py
@@ -6,46 +6,14 @@ from mongodbforms.documentoptions import DocumentMetaWrapper, LazyDocumentMetaWr
 from mongodbforms.fieldgenerator import MongoDefaultFormFieldGenerator
 
 try:
-    from django.utils.module_loading import import_by_path
+    from django.utils.module_loading import import_string
 except ImportError:
-    # this is only in Django's devel version for now
-    # and the following code comes from there. Yet it's too nice to
-    # pass on this. So we do define it here for now.
-    import sys
-    from django.core.exceptions import ImproperlyConfigured
-    from django.utils.importlib import import_module
-    from django.utils import six
-
-    def import_by_path(dotted_path, error_prefix=''):
-        """
-        Import a dotted module path and return the attribute/class designated
-        by the last name in the path. Raise ImproperlyConfigured if something
-        goes wrong.
-        """
-        try:
-            module_path, class_name = dotted_path.rsplit('.', 1)
-        except ValueError:
-            raise ImproperlyConfigured("%s%s doesn't look like a module path" %
-                                       (error_prefix, dotted_path))
-        try:
-            module = import_module(module_path)
-        except ImportError as e:
-            msg = '%sError importing module %s: "%s"' % (
-                error_prefix, module_path, e)
-            six.reraise(ImproperlyConfigured, ImproperlyConfigured(msg),
-                        sys.exc_info()[2])
-        try:
-            attr = getattr(module, class_name)
-        except AttributeError:
-            raise ImproperlyConfigured(
-                '%sModule "%s" does not define a "%s" attribute/class' %
-                (error_prefix, module_path, class_name))
-        return attr
+    from django.utils.module_loading import import_by_path as import_string
 
 
 def load_field_generator():
     if hasattr(settings, 'MONGODBFORMS_FIELDGENERATOR'):
-        return import_by_path(settings.MONGODBFORMS_FIELDGENERATOR)
+        return import_string(settings.MONGODBFORMS_FIELDGENERATOR)
     return MongoDefaultFormFieldGenerator
 
 

--- a/mongodbforms/util.py
+++ b/mongodbforms/util.py
@@ -6,7 +6,7 @@ from mongodbforms.documentoptions import DocumentMetaWrapper, LazyDocumentMetaWr
 from mongodbforms.fieldgenerator import MongoDefaultFormFieldGenerator
 
 try:
-    from django.utils.module_loading import import_string
+    from django.utils.module_loading import import_string  # Django 1.8
 except ImportError:
     from django.utils.module_loading import import_by_path as import_string
 

--- a/mongodbforms/widgets.py
+++ b/mongodbforms/widgets.py
@@ -7,7 +7,7 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.core.validators import EMPTY_VALUES
 try:
-    from django.forms.utils import flatatt
+    from django.forms.utils import flatatt  # Django 1.8
 except ImportError:
     from django.forms.util import flatatt
 

--- a/mongodbforms/widgets.py
+++ b/mongodbforms/widgets.py
@@ -6,7 +6,10 @@ from django.forms.widgets import (Widget, Media, TextInput, FileInput,
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.core.validators import EMPTY_VALUES
-from django.forms.util import flatatt
+try:
+    from django.forms.utils import flatatt
+except ImportError:
+    from django.forms.util import flatatt
 
 
 class Html5SplitDateTimeWidget(SplitDateTimeWidget):


### PR DESCRIPTION
FYI, I didn't handle the use of `get_declared_fields()`. It's scheduled for deprecation in 1.9, but it would take some time to cleanup the code (meta classes...)
