### PR TITLE
BAT-7558 - Simple list fields broken

### DIFF
--- a/mongodbforms/fieldgenerator.py
+++ b/mongodbforms/fieldgenerator.py
@@ -115,7 +115,7 @@ class MongoFormFieldGenerator(object):
         return value.lower() == 'true'
 
     def get_field_label(self, field):
-        if hasattr(field, 'verbose_name') and field.verbose_name:
+        if getattr(field, 'verbose_name', None):
             return capfirst(field.verbose_name)
         if field.name is not None:
             return capfirst(create_verbose_name(field.name))

--- a/mongodbforms/fieldgenerator.py
+++ b/mongodbforms/fieldgenerator.py
@@ -115,7 +115,7 @@ class MongoFormFieldGenerator(object):
         return value.lower() == 'true'
 
     def get_field_label(self, field):
-        if field.verbose_name:
+        if hasattr(field, 'verbose_name') and field.verbose_name:
             return capfirst(field.verbose_name)
         if field.name is not None:
             return capfirst(create_verbose_name(field.name))

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -8,6 +8,7 @@ class MyDocument(Document):
     mystring = fields.StringField()
     myverbosestring = fields.StringField(verbose_name="Foobar")
     myrequiredstring = fields.StringField(required=True)
+    list_of_strings = fields.ListField(fields.StringField())
 
 
 class MyForm(DocumentForm):
@@ -23,7 +24,8 @@ class SimpleDocumentTest(unittest.TestCase):
 
     def test_form(self):
         form = MyForm()
-        self.assertEquals(len(form.fields), 3)
+        self.assertEquals(len(form.fields), 4)
         self.assertFalse(form.fields['mystring'].required)
         self.assertEquals(form.fields['myverbosestring'].label, "Foobar")
         self.assertTrue(form.fields['myrequiredstring'].required)
+        self.assertEqual(form.fields['list_of_strings'].label, "List of strings")


### PR DESCRIPTION
Pretty sure this is caused by https://github.com/MongoEngine/mongoengine/pull/1129: in that PR, `verbose_name` is no longer an actual attribute of fields classes. I guess this issue has something to with this document wrapper, scouring fields and trying to ensure the presence of `verbose_name` on them:
https://github.com/Work4Labs/django-mongodbforms/blob/ebaa8828524d0230969a1a0036e5eb98f12eb48b/mongodbforms/documentoptions.py#L187-L188
When the form generators encounters a list field though, it tries to grab data from its `field.field`:
https://github.com/Work4Labs/django-mongodbforms/blob/ebaa8828524d0230969a1a0036e5eb98f12eb48b/mongodbforms/fieldgenerator.py#L338
Sub-field that seems to be ignored by the wrapper, and thus does not have the optional `verbose_name`. If the list's field is declared explicitly with a `verbose_name`, the issue does not occur.

→ It seems acceptable [for `help_text` to be undefined](https://github.com/Work4Labs/django-mongodbforms/blob/ebaa8828524d0230969a1a0036e5eb98f12eb48b/mongodbforms/fieldgenerator.py#L124-L128), so I'm doing the same for `verbose_name`.